### PR TITLE
SRV-795 feat - reading language from url

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -111,6 +111,14 @@ export const URL_PARAMS = {
     name: 'focused_chart',
     type: 'number',
   },
+  language: {
+    name: 'lang',
+    type: 'string'
+  },
+  currency: {
+    name: 'currency',
+    type: 'string'
+  }
 } as const;
 
 export const RESERVED_CHART_URL_PARAMS: string[] = [

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2652,7 +2652,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return False
 
         dashboards = [
-            r for r in user.resources if r["type"] == GuestTokenResourceType.DASHBOARD
+            r for r in user.resources if r["type"] == GuestTokenResourceType.DASHBOARD.value
         ]
 
         # TODO (embedded): remove this check once uuids are rolled out

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -33,6 +33,7 @@ from flask import (
     redirect,
     Response,
     session,
+    request
 )
 from flask_appbuilder import BaseView, expose, Model, ModelView
 from flask_appbuilder.actions import action
@@ -347,8 +348,11 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
 
 
 def common_bootstrap_payload() -> dict[str, Any]:
+    locale = get_locale()
+    if request.args.get('lang'):
+        locale = Locale.parse(request.args.get('lang'))
     return {
-        **cached_common_bootstrap_data(utils.get_user_id(), get_locale()),
+        **cached_common_bootstrap_data(utils.get_user_id(), locale),
         "flash_messages": get_flashed_messages(with_categories=True),
     }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix(embedded dashboard): resource type was not checked appropriately against enum.
feat(UI): added currency and language to URL_PARAMS
feat(API):  using language based on query parameter if found and defaulting to session value 
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Embed a dashboard using the superset-embedded-sdk package.
- Set lang and currency in the urlParams options.
- Depending on the chosen language, the ui will be rendered with it.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
