### PR TITLE
WI-7477 Migrate superset-service checkout to bridge PAT

### DIFF
--- a/.github/workflows/deploy-service-to-environment.yml
+++ b/.github/workflows/deploy-service-to-environment.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           repository: Webgains/superset-service
           ref: main
-          ssh-key: ${{ secrets.SSH_KEY }}
+          token: ${{ secrets.GH_PRIVATE_SOURCE_READ_PAT }}
           path: cdk
 
       - name: Assume AWS role


### PR DESCRIPTION
## Summary
- Replace `ssh-key: ${{ secrets.SSH_KEY }}` with `token: ${{ secrets.GH_PRIVATE_SOURCE_READ_PAT }}` for submodule / private repo checkout

Part of WI-7477 Phase 4. Requires wg-ansible PR #1725 merge and `GH_PRIVATE_SOURCE_READ_PAT` secret sync to this repo.

## Test plan
- [ ] Submodule checkout succeeds in CI
- [ ] jira-lint passes

Made with [Cursor](https://cursor.com)