### PR TITLE
SUP-217 Migrate submodule checkout to bridge PAT

### DIFF
--- a/.github/workflows/deploy-service-to-environment.yml
+++ b/.github/workflows/deploy-service-to-environment.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           repository: Webgains/superset-service
           ref: main
-          ssh-key: ${{ secrets.SSH_KEY }}
+          token: ${{ secrets.GH_PRIVATE_SOURCE_READ_PAT }}
           path: cdk
 
       - name: Assume AWS role


### PR DESCRIPTION
## Summary
Migrate CI from retired `SSH_KEY` to scoped bridge PAT `GH_PRIVATE_SOURCE_READ_PAT` for private submodule checkout (WI-7477).

## Ticket
https://webgains.atlassian.net/browse/SUP-217

## Changes
- Replace SSH deploy key checkout with HTTPS + `GH_PRIVATE_SOURCE_READ_PAT`
- Align with org bridge credential migration (epic WI-7477)

## Test plan
- [x] CI workflows pass on this PR

Made with [Cursor](https://cursor.com)